### PR TITLE
Update ykval-synclib.php

### DIFF
--- a/ykval-synclib.php
+++ b/ykval-synclib.php
@@ -330,8 +330,6 @@ class SyncLib
 				$server = strtok(curl_getinfo($handle, CURLINFO_EFFECTIVE_URL), "?");
 				$entry = $entries[$server];
 				$this->log(LOG_DEBUG, "handle indicated to be for $server.");
-				curl_multi_remove_handle($mh, $handle);
-				$handles--;
 				if ($info['result'] === CURLE_OK) {
 					$response = curl_multi_getcontent($handle);
 					if (preg_match('/status=OK/', $response))
@@ -439,11 +437,13 @@ class SyncLib
 					$this->log(LOG_NOTICE, 'Timeout. Stopping queue resync for server ' . $entry['server']);
 					unset($server_list[$server]);
 				}
+				curl_multi_remove_handle($mh, $handle);
+				$handles--;
 			}
 		}
 
 		foreach ($ch as $handle) {
-			curl_close($ch);
+			curl_close($handle);
 		}
 
 		curl_multi_close($mh);


### PR DESCRIPTION
According to https://secure.php.net/manual/en/function.curl-multi-info-read.php, "The data the returned resource points to will not survive calling curl_multi_remove_handle()." Therefore, it is better to call curl_multi_remove_handle() after we're finished with the handle and its related info data returned from curl_multi_info_read(). Not doing so will make the info data unreadable. This could lead to logging when re-syncing that makes it appear as though syncing is not successful when in reality it is working just fine.